### PR TITLE
Fix webserver profile manifest syntax

### DIFF
--- a/modules/profiles/manifests/webserver.pp
+++ b/modules/profiles/manifests/webserver.pp
@@ -1,5 +1,5 @@
-
 class profiles::webserver {
-	class { 'webserver':
-		env1 => production,
+  class { 'webserver':
+    env1 => 'production',
+  }
 }


### PR DESCRIPTION
## Summary
- fix syntax and formatting in `profiles::webserver` manifest

## Testing
- `bundle install` *(fails: 403 Forbidden – no internet)*

------
https://chatgpt.com/codex/tasks/task_e_688b123bdc688328936c857b0d94dcc4